### PR TITLE
Standardisation php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 Tags come from PHP version installed + specific indication if needed.
 Be careful : the list is ordered by more recent tag first, not php version it-self, as recent version may include fixes and are added only if needed.
 
+
+## 8.1.23
+Update date : 18/09/2023
+
+Update PHP to 8.1.23
+
+- Entrypoint back to php default
+- Zol common v8.0.3 and later required
+
 ## 8.1.0
 Update date : 6/12/2021 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM composer:2.1.14 AS composer
 
-FROM php:8.1.8-fpm
+FROM php:8.1.23-fpm
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 COPY --from=composer /usr/bin/composer /usr/bin/composer

--- a/script/entry.sh
+++ b/script/entry.sh
@@ -37,4 +37,11 @@ main () {
 wait_all_hosts
 main
 
-bash -c "$*"
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- php-fpm "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Update PHP to 8.1.23

- Entrypoint back to php default
- Zol common v8.0.3 and later required