### PR TITLE
Draft: Also prepare the filesystem when a command is given

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,17 +66,18 @@ ADD logrotate/cron /etc/periodic/daily/logrotate-cron
 # Custom PHP configuration
 COPY php/php.ini /usr/local/etc/php/php.ini
 
+COPY script/prepare.sh /opt/scripts/prepare.sh
 COPY script/start.sh /opt/scripts/start.sh
 COPY script/entry.sh /opt/scripts/entry.sh
 
 
 # Make sure every user can start the container
 RUN chown -R 1000:1000 /opt/scripts \
-    && chmod 0777 /opt/scripts/start.sh /opt/scripts/entry.sh \
+    && chmod 0777 /opt/scripts/{prepare,start,entry}.sh \
     && chmod +x /etc/periodic/daily/logrotate-cron
 
 
 WORKDIR /var/www/html
 
-ENTRYPOINT ["/opt/scripts/entry.sh"]
+ENTRYPOINT ["/opt/scripts/prepare.sh", "/opt/scripts/entry.sh"]
 CMD ["/opt/scripts/start.sh"]

--- a/script/prepare.sh
+++ b/script/prepare.sh
@@ -35,7 +35,17 @@ symfony_logs() {
 	www_folder "${html_dir}/var"
 }
 
+symfony_vendor() {
+	www_folder "${html_dir}/vendor"
+}
+
+symfony_public() {
+	www_folder "${html_dir}/public"
+}
+
 php_logs
 symfony_logs
+symfony_vendor
+symfony_public
 
 exec "$@"

--- a/script/prepare.sh
+++ b/script/prepare.sh
@@ -11,9 +11,7 @@ php_logs() {
 		&& touch "${access_log_file}" \
 		&& touch "${error_log_file}"
 
-	if [ -n "$UID" ] && [ -n "$GID" ]; then
-		chown -R "$UID:$GID" "${log_dir}"
-	fi
+	chown -R www-data "${log_dir}"
 
 	# The "c" supplementary letter is needed because the first letter will be cut at replacement.
 	sed -i \
@@ -32,12 +30,8 @@ symfony_logs() {
 	html_dir="/var/www/html"
 	var_dir="${html_dir}/var"
 
-	if [ -n "$UID" ] && [ -n "$GID" ]; then
-		# To avoid permissions issues, create directly the /var/www/html/var directory and give it to $UID:$GID
-
-		mkdir -p "${var_dir}"
-		chown -R "$UID:$GID ${var_dir}"
-	fi
+	mkdir -p "${var_dir}"
+	chown -R www-data "${var_dir}"
 }
 
 php_logs

--- a/script/prepare.sh
+++ b/script/prepare.sh
@@ -1,0 +1,46 @@
+#!/bin/sh -e
+
+php_logs() {
+	conf_file="/usr/local/etc/php-fpm.d/www.conf"
+
+	log_dir="/var/log/php"
+	access_log_file="${log_dir}/access.log"
+	error_log_file="${log_dir}/error.log"
+
+	mkdir -p "${log_dir}" \
+		&& touch "${access_log_file}" \
+		&& touch "${error_log_file}"
+
+	if [ -n "$UID" ] && [ -n "$GID" ]; then
+		chown -R "$UID:$GID" "${log_dir}"
+	fi
+
+	# The "c" supplementary letter is needed because the first letter will be cut at replacement.
+	sed -i \
+		-e '/^;catch_workers_output/ccatch_workers_output = yes' \
+		-e '/^;log_level/clog_level = debug' \
+		-e '/^;listen/clisten = 9000' \
+		-e '/^;access.log/caccess.log = /var/log/php/access.log' \
+		-e '/^;php_flag\[display_errors\]/cphp_flag[display_errors] = off' \
+		-e '/^;php_admin_value\[error_log\]/cphp_admin_value[error_log] = /var/log/php/error.log' \
+		-e '/^;php_admin_flag\[log_errors\]/cphp_admin_flag[log_errors] = on' \
+		-e '/^;clear_env/cclear_env = no' \
+		"${conf_file}"
+}
+
+symfony_logs() {
+	html_dir="/var/www/html"
+	var_dir="${html_dir}/var"
+
+	if [ -n "$UID" ] && [ -n "$GID" ]; then
+		# To avoid permissions issues, create directly the /var/www/html/var directory and give it to $UID:$GID
+
+		mkdir -p "${var_dir}"
+		chown -R "$UID:$GID ${var_dir}"
+	fi
+}
+
+php_logs
+symfony_logs
+
+exec "$@"

--- a/script/prepare.sh
+++ b/script/prepare.sh
@@ -1,19 +1,24 @@
 #!/bin/sh -e
 
+html_dir="/var/www/html"
+
+www_folder() {
+	mkdir -p "$1"
+	chown -R www-data "$1"
+}
+
+www_file() {
+	touch "$1"
+	chown www-data "$1"
+}
+
 php_logs() {
-	conf_file="/usr/local/etc/php-fpm.d/www.conf"
+	www_folder "/var/log/php"
+	www_file "/var/log/php/access.log"
+	www_file "/var/log/php/error.log"
 
-	log_dir="/var/log/php"
-	access_log_file="${log_dir}/access.log"
-	error_log_file="${log_dir}/error.log"
-
-	mkdir -p "${log_dir}" \
-		&& touch "${access_log_file}" \
-		&& touch "${error_log_file}"
-
-	chown -R www-data "${log_dir}"
-
-	# The "c" supplementary letter is needed because the first letter will be cut at replacement.
+	# The "c" supplementary letter is needed because the first letter will be cut
+	# at replacement.
 	sed -i \
 		-e '/^;catch_workers_output/ccatch_workers_output = yes' \
 		-e '/^;log_level/clog_level = debug' \
@@ -23,15 +28,11 @@ php_logs() {
 		-e '/^;php_admin_value\[error_log\]/cphp_admin_value[error_log] = /var/log/php/error.log' \
 		-e '/^;php_admin_flag\[log_errors\]/cphp_admin_flag[log_errors] = on' \
 		-e '/^;clear_env/cclear_env = no' \
-		"${conf_file}"
+		"/usr/local/etc/php-fpm.d/www.conf"
 }
 
 symfony_logs() {
-	html_dir="/var/www/html"
-	var_dir="${html_dir}/var"
-
-	mkdir -p "${var_dir}"
-	chown -R www-data "${var_dir}"
+	www_folder "${html_dir}/var"
 }
 
 php_logs

--- a/script/start.sh
+++ b/script/start.sh
@@ -1,47 +1,6 @@
 #!/usr/bin/env bash
 set -o errexit
 
-php_logs() {
-    local conf_file="/usr/local/etc/php-fpm.d/www.conf"
-
-    local log_dir="/var/log/php"
-    local access_log_file="${log_dir}/access.log"
-    local error_log_file="${log_dir}/error.log"
-
-    mkdir -p ${log_dir} \
-        && touch ${access_log_file} \
-        && touch ${error_log_file};
-
-    if [ ! -z "$UID" ] && [ ! -z "$GID" ]; then
-        chown -R $UID:$GID ${log_dir}
-    fi
-
-    # The "c" supplementary letter is needed because the first letter will be cut at replacement.
-    sed -i '/^;catch_workers_output/ccatch_workers_output = yes' ${conf_file} \
-        && sed -i '/^;log_level/clog_level = debug' ${conf_file} \
-        && sed -i '/^;listen/clisten = 9000' ${conf_file} \
-        && sed -i '/^;access.log/caccess.log = /var/log/php/access.log' ${conf_file} \
-        && sed -i '/^;php_flag\[display_errors\]/cphp_flag[display_errors] = off' ${conf_file} \
-        && sed -i '/^;php_admin_value\[error_log\]/cphp_admin_value[error_log] = /var/log/php/error.log' ${conf_file} \
-        && sed -i '/^;php_admin_flag\[log_errors\]/cphp_admin_flag[log_errors] = on' ${conf_file} \
-        && sed -i '/^;clear_env/cclear_env = no' ${conf_file}
-}
-
-symfony_logs() {
-    local html_dir="/var/www/html"
-    local var_dir="${html_dir}/var"
-
-    if [ ! -z "$UID" ] && [ ! -z "$GID" ]; then
-        # To avoid permissions issues, create directly the /var/www/html/var directory and give it to $UID:$GID
-
-        mkdir -p ${var_dir}
-        chown -R $UID:$GID ${var_dir}
-    fi
-}
-
-php_logs
-symfony_logs
-
 cron -L 15
 
 # Add host ip as an alias in /etc/hosts to allow container to ping it without guessing it's ip everytime


### PR DESCRIPTION
start.sh is run when no command is given when starting a container.

But when the makefiles run the container, with a composer install
command, we also need to make sure the filesystem got the correct ACLs.

To do so, we now prepare the filesystem in a new prepare.sh entrypoint.

We use an additional prepare.sh, and not entry.sh, because it allow the
projects to extends this, without rewriting entry.sh.

This also clean and improve the shell code.
